### PR TITLE
fix: incorrect loop start index in _regen

### DIFF
--- a/randcrack/randcrack.py
+++ b/randcrack/randcrack.py
@@ -197,7 +197,7 @@ class RandCrack:
             y = self._or_nums(self._and_nums(self.mt[kk], u_bits), self._and_nums(self.mt[kk + 1], l_bits))
             self.mt[kk] = self._xor_nums(self._xor_nums(self.mt[kk + M], y[:-1]), mag01[y[-1] & 1])
 
-        for kk in range(N - M - 1, N - 1):
+        for kk in range(N - M, N - 1):
             y = self._or_nums(self._and_nums(self.mt[kk], u_bits), self._and_nums(self.mt[kk + 1], l_bits))
             self.mt[kk] = self._xor_nums(self._xor_nums(self.mt[kk + (M - N)], y[:-1]), mag01[y[-1] & 1])
 


### PR DESCRIPTION
After this fix, the accuracy is 100% for arbitrarily long generations.