### PR TITLE
Add `random.random()` support

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,9 +31,7 @@ As well, you must feed the cracker exactly after new seed is presented, or after
 
 Cracker has one method for feeding: `submit(n)`. After submitting 624 integers it won't take any more and will be ready for predicting new numbers.
 
-Cracker can predict new numbers with following methods, which work exactly the same as their siblings from the `random` module but without `predict_` prefix. These are: `predict_getrandbits`, `predict_randbelow`, `predict_randrange`,  `predict_randint` and `predict_choice`
-
-**Note:** Cracker does not implement prediction of `random()` function since it is based on the `os.urandom` module which is based on `/dev/urandom`.
+Cracker can predict new numbers with following methods, which work exactly the same as their siblings from the `random` module but without `predict_` prefix. These are: `predict_getrandbits`, `predict_randbelow`, `predict_randrange`,  `predict_randint`, `predict_choice` and `predict_random`
 
 Here's an example usage:
 ```python

--- a/randcrack/randcrack.py
+++ b/randcrack/randcrack.py
@@ -98,6 +98,11 @@ class RandCrack:
             raise IndexError('Cannot choose from an empty sequence')
         return seq[i]
 
+    def predict_random(self):
+        a = self._to_int(self._predict_32()) >> 5
+        b = self._to_int(self._predict_32()) >> 6
+        return ((a*67108864.0)+b)/9007199254740992.0
+
     def _to_bitarray(self, num):
         k = [int(x) for x in bin(num)[2:]]
         return [0] * (32 - len(k)) + k

--- a/tests/test_randcrack.py
+++ b/tests/test_randcrack.py
@@ -50,3 +50,12 @@ def test_predict_first_1000_close():
         cracker.submit(random.randint(0, 4294967294))
 
     assert sum([random.getrandbits(32) == cracker.predict_getrandbits(32) for _ in range(1000)]) >= 980
+
+def test_predict_random():
+    random.seed(time.time())
+
+    cracker = RandCrack()
+
+    for i in range(624):
+        cracker.submit(random.randint(0, 4294967294))
+    assert sum([random.random() == cracker.predict_random() for _ in range(1000)]) >= 980


### PR DESCRIPTION
resolves #10 

Adds a `predict_random` function based on the code for the `random` implementation (note: the constants are 2**26 and 2**53 respectively, I kept them as they were in the source), and a test to show that it's as accurate as the rest of the library.

This PR also removes the incorrent note about `random.random()` using `os.urandom` from the README and adds the new method to the list there.